### PR TITLE
Fix truncation of version string in desktop app

### DIFF
--- a/WorldBuilder/Views/ProjectSelectionView.axaml
+++ b/WorldBuilder/Views/ProjectSelectionView.axaml
@@ -121,11 +121,14 @@
                 <StackPanel Orientation="Horizontal" Spacing="10">
                     <TextBlock FontSize="42" Text="WorldBuilder" />
                     <TextBlock
+                        MaxWidth="100"
                         Margin="0,0,0,8"
                         VerticalAlignment="Bottom"
                         FontSize="14"
                         Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
-                        Text="{Binding AppVersion}" />
+                        Text="{Binding AppVersion}"
+                        TextTrimming="CharacterEllipsis"
+                        ToolTip.Tip="{Binding AppVersion}" />
                 </StackPanel>
             </StackPanel>
 


### PR DESCRIPTION
AppVersion is a super long string and it overflows for me with a dev build. This PR truncates it if needed and adds a tooltip so you can see the whole thing.

<img width="697" height="208" alt="Screenshot 2025-12-04 at 8 52 23 PM" src="https://github.com/user-attachments/assets/8a845a0b-428f-4a0f-9b1e-a5b91221e370" />
