### PR TITLE
add setting for alternative platform-dependent mouselook method

### DIFF
--- a/WorldBuilder.Shared/Lib/EditorState.cs
+++ b/WorldBuilder.Shared/Lib/EditorState.cs
@@ -29,6 +29,7 @@ namespace WorldBuilder.Shared.Lib {
         [ObservableProperty] private int _objectRenderDistance = 12;
         [ObservableProperty] private float _maxDrawDistance = 40000f;
         [ObservableProperty] private float _mouseSensitivity = 1.0f;
+        [ObservableProperty] private bool _altMouseLook = false;
         [ObservableProperty] private bool _enableCameraCollision = true;
     }
 }

--- a/WorldBuilder/Lib/Platform/LinuxX11Mouse.cs
+++ b/WorldBuilder/Lib/Platform/LinuxX11Mouse.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace WorldBuilder.Lib.Platform;
+
+/// <summary>
+/// Provides Linux X11 cursor position functionality using XWarpPointer.
+/// Uses cursor warping similar to Windows: when the cursor reaches the edge,
+/// it's warped back to the center, generating motion events.
+/// </summary>
+public static class LinuxX11Mouse {
+
+    private const string LibX11 = "libX11.so.6";
+
+    [DllImport(LibX11, CallingConvention = CallingConvention.Cdecl)]
+    private static extern int XWarpPointer(
+        IntPtr display,
+        IntPtr src_w,
+        IntPtr dest_w,
+        int src_x,
+        int src_y,
+        uint src_width,
+        uint src_height,
+        int dest_x,
+        int dest_y);
+
+    [DllImport(LibX11, CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr XOpenDisplay(string? display_name);
+
+    [DllImport(LibX11, CallingConvention = CallingConvention.Cdecl)]
+    private static extern int XCloseDisplay(IntPtr display);
+
+    [DllImport(LibX11, CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr XDefaultRootWindow(IntPtr display);
+
+    [DllImport(LibX11, CallingConvention = CallingConvention.Cdecl)]
+    private static extern int XFlush(IntPtr display);
+
+    private static IntPtr? _display;
+    private static IntPtr _rootWindow;
+
+    /// <summary>
+    /// Gets the X11 display connection. Caches it for reuse.
+    /// </summary>
+    private static IntPtr GetDisplay() {
+        if (_display == null) {
+            _display = XOpenDisplay(null);
+            if (_display != IntPtr.Zero) {
+                _rootWindow = XDefaultRootWindow(_display.Value);
+            }
+        }
+        return _display.Value;
+    }
+
+    /// <summary>
+    /// Warps the cursor to the specified screen coordinates.
+    /// On X11, this is how mouselook confinement is typically implemented.
+    /// </summary>
+    public static void SetCursorPos(int x, int y) {
+        var display = GetDisplay();
+        XWarpPointer(display, IntPtr.Zero, _rootWindow, 0, 0, 0, 0, x, y);
+        XFlush(display);
+    }
+
+    /// <summary>
+    /// Cleanup X11 display connection when done.
+    /// </summary>
+    public static void Cleanup() {
+        if (_display != null && _display.Value != IntPtr.Zero) {
+            XCloseDisplay(_display.Value);
+            _display = null;
+        }
+    }
+}

--- a/WorldBuilder/Lib/Platform/MacOSMouse.cs
+++ b/WorldBuilder/Lib/Platform/MacOSMouse.cs
@@ -1,0 +1,107 @@
+using System.Runtime.InteropServices;
+using Avalonia.Controls;
+
+namespace WorldBuilder.Lib.Platform;
+
+/// <summary>
+/// Provides macOS cursor position functionality using CoreGraphics.
+/// Uses cursor warping similar to Windows and X11: the cursor is warped back to center,
+/// generating motion events for mouselook functionality.
+/// </summary>
+public static class MacOSMouse
+{
+    private const string CoreGraphicsFramework = "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics";
+
+    /// <summary>
+    /// Warps the mouse cursor to the specified screen coordinates.
+    /// On macOS, this is equivalent to SetCursorPos on Windows or XWarpPointer on X11.
+    /// </summary>
+    [DllImport(CoreGraphicsFramework, CallingConvention = CallingConvention.Cdecl)]
+    private static extern int CGWarpMouseCursorPosition(CGPoint newCursorPosition);
+
+    /// <summary>
+    /// Gets the current position of the mouse cursor.
+    /// </summary>
+    [DllImport(CoreGraphicsFramework, CallingConvention = CallingConvention.Cdecl)]
+    private static extern int CGGetLastMouseDelta(out int deltaX, out int deltaY);
+
+    /// <summary>
+    /// Associates or disassociates mouse movements with the visible cursor position.
+    /// When set to false, mouse movements don't move the visible cursor, but events are still generated.
+    /// Useful for mouselook where you want to hide the cursor and track raw movement.
+    /// </summary>
+    [DllImport(CoreGraphicsFramework, CallingConvention = CallingConvention.Cdecl)]
+    private static extern int CGAssociateMouseAndMouseCursorPosition(bool associateMouseAndCursor);
+
+    /// <summary>
+    /// Structure representing a point in CoreGraphics.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    private struct CGPoint
+    {
+        public double X;
+        public double Y;
+
+        public CGPoint(double x, double y)
+        {
+            X = x;
+            Y = y;
+        }
+    }
+
+    /// <summary>
+    /// Warps the cursor to the specified screen coordinates.
+    /// This is the primary method for implementing mouselook on macOS.
+    /// </summary>
+    public static int SetCursorPos(int x, int y)
+    {
+        return CGWarpMouseCursorPosition(new CGPoint(x, y));
+    }
+
+    /// <summary>
+    /// Gets the Avalonia window handle for macOS.
+    /// On macOS, this typically represents an NSWindow or similar native window object.
+    /// </summary>
+    public static IntPtr GetAvaloniaWindowHandle(Window window)
+    {
+        var platformHandle = window.TryGetPlatformHandle();
+
+        if (platformHandle != null) {
+            if (platformHandle.Handle is IntPtr windowHandle) {
+                return windowHandle;
+            }
+            else if (platformHandle.Handle is nint handleValue) {
+                return new IntPtr(handleValue);
+            }
+        }
+        return IntPtr.Zero;
+    }
+
+    /// <summary>
+    /// Disassociate mouse movement from cursor position.
+    /// When disabled, the cursor doesn't move visually, but you still receive motion events.
+    /// This is useful for mouselook where you hide the cursor and warp it back to center when it reaches the viewport edge.
+    /// </summary>
+    public static int DisassociateMouseAndCursor()
+    {
+        return CGAssociateMouseAndMouseCursorPosition(false);
+    }
+
+    /// <summary>
+    /// Reassociate mouse movement with cursor position (restore normal behavior).
+    /// Call this when exiting mouselook mode.
+    /// </summary>
+    public static int AssociateMouseAndCursor()
+    {
+        return CGAssociateMouseAndMouseCursorPosition(true);
+    }
+
+    /// <summary>
+    /// Gets the last delta of mouse movement.
+    /// This can be useful for tracking relative motion when the cursor is disassociated.
+    /// </summary>
+    public static void GetLastMouseDelta(out int deltaX, out int deltaY)
+    {
+        CGGetLastMouseDelta(out deltaX, out deltaY);
+    }
+}

--- a/WorldBuilder/Lib/Platform/Platform.cs
+++ b/WorldBuilder/Lib/Platform/Platform.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace WorldBuilder.Lib.Platform {
+    public static class Platform {
+        public static bool IsWindows { get; private set; }
+        public static bool IsLinux { get; private set; }
+        public static bool IsMacOS { get; private set; }
+        public static bool IsX11 { get; private set; }
+        public static bool IsWayland { get; private set; }
+
+        static Platform() {
+            IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            IsLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            IsMacOS = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+
+            if (IsLinux)
+                DetectLinuxDisplayServer();
+        }
+
+        private static void DetectLinuxDisplayServer() {
+            // Check WAYLAND_DISPLAY environment variable first
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WAYLAND_DISPLAY"))) {
+                IsWayland = true;
+                return;
+            }
+
+            // Check XDG_SESSION_TYPE environment variable
+            var sessionType = Environment.GetEnvironmentVariable("XDG_SESSION_TYPE");
+            if (sessionType == "wayland") {
+                IsWayland = true;
+                return;
+            }
+            else if (sessionType == "x11") {
+                IsX11 = true;
+                return;
+            }
+
+            // Check DISPLAY environment variable (X11)
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DISPLAY"))) {
+                IsX11 = true;
+                return;
+            }
+        }
+    }
+}

--- a/WorldBuilder/Lib/Platform/WindowsMouse.cs
+++ b/WorldBuilder/Lib/Platform/WindowsMouse.cs
@@ -1,0 +1,16 @@
+using System.Runtime.InteropServices;
+
+namespace WorldBuilder.Lib.Platform;
+
+/// <summary>
+/// Provides Windows cursor position functionality.
+/// </summary>
+public static class WindowsMouse
+{
+    [DllImport("user32.dll")]
+    public static extern bool GetCursorPos(out int x, out int y);
+
+    [DllImport("user32.dll")]
+    public static extern bool SetCursorPos(int x, int y);
+
+}

--- a/WorldBuilder/Lib/Settings/LandscapeEditorSettings.cs
+++ b/WorldBuilder/Lib/Settings/LandscapeEditorSettings.cs
@@ -93,15 +93,20 @@ namespace WorldBuilder.Lib.Settings {
         private float _mouseSensitivity = 1.0f;
         public float MouseSensitivity { get => _mouseSensitivity; set => SetProperty(ref _mouseSensitivity, value); }
 
+        [SettingDescription("Alternative mouselook method uses platform-dependent code")]
+        [SettingOrder(3)]
+        private bool _altMouseLook = false;
+        public bool AltMouseLook { get => _altMouseLook; set => SetProperty(ref _altMouseLook, value); }
+
         [SettingDescription("Camera movement speed in units per second")]
         [SettingRange(1, 20000, 10, 50)]
         [SettingFormat("{0:F0}")]
-        [SettingOrder(3)]
+        [SettingOrder(4)]
         private float _movementSpeed = 1000f;
         public float MovementSpeed { get => _movementSpeed; set => SetProperty(ref _movementSpeed, value); }
 
         [SettingDescription("Prevent camera from going below terrain or passing through walls")]
-        [SettingOrder(4)]
+        [SettingOrder(5)]
         private bool _enableCameraCollision = true;
         public bool EnableCameraCollision { get => _enableCameraCollision; set => SetProperty(ref _enableCameraCollision, value); }
     }

--- a/WorldBuilder/Modules/Landscape/LandscapeViewModel.cs
+++ b/WorldBuilder/Modules/Landscape/LandscapeViewModel.cs
@@ -580,6 +580,7 @@ public partial class LandscapeViewModel : ViewModelBase, IDisposable, IToolModul
         EditorState.ObjectRenderDistance = _settings.Landscape.Rendering.ObjectRenderDistance;
         EditorState.MaxDrawDistance = _settings.Landscape.Camera.MaxDrawDistance;
         EditorState.MouseSensitivity = _settings.Landscape.Camera.MouseSensitivity;
+        EditorState.AltMouseLook = _settings.Landscape.Camera.AltMouseLook;
         EditorState.EnableCameraCollision = _settings.Landscape.Camera.EnableCameraCollision;
         EditorState.EnableTransparencyPass = _settings.Landscape.Rendering.EnableTransparencyPass;
         EditorState.TimeOfDay = _settings.Landscape.Rendering.TimeOfDay;
@@ -607,6 +608,7 @@ public partial class LandscapeViewModel : ViewModelBase, IDisposable, IToolModul
             case nameof(EditorState.ObjectRenderDistance): _settings.Landscape.Rendering.ObjectRenderDistance = EditorState.ObjectRenderDistance; break;
             case nameof(EditorState.MaxDrawDistance): _settings.Landscape.Camera.MaxDrawDistance = EditorState.MaxDrawDistance; break;
             case nameof(EditorState.MouseSensitivity): _settings.Landscape.Camera.MouseSensitivity = EditorState.MouseSensitivity; break;
+            case nameof(EditorState.AltMouseLook): _settings.Landscape.Camera.AltMouseLook = EditorState.AltMouseLook; break;
             case nameof(EditorState.EnableCameraCollision): _settings.Landscape.Camera.EnableCameraCollision = EditorState.EnableCameraCollision; break;
             case nameof(EditorState.EnableTransparencyPass): _settings.Landscape.Rendering.EnableTransparencyPass = EditorState.EnableTransparencyPass; break;
             case nameof(EditorState.TimeOfDay): _settings.Landscape.Rendering.TimeOfDay = EditorState.TimeOfDay; break;


### PR DESCRIPTION
This fixes a bug while mouselooking where the cursor can move outside of the bounds of the application window, which prevents the application from receiving mousewheel events to change the movement speed