### PR TITLE
organized project settings

### DIFF
--- a/WorldBuilder/Lib/Settings/ProjectSettings.cs
+++ b/WorldBuilder/Lib/Settings/ProjectSettings.cs
@@ -31,10 +31,54 @@ namespace WorldBuilder.Lib.Settings {
         private bool _isMaximized = false;
         public bool IsMaximized { get => _isMaximized; set => SetProperty(ref _isMaximized, value); }
 
+        [SettingHidden]
+        private ProjectGraphicsSettings _graphics = new();
+        public ProjectGraphicsSettings Graphics {
+            get => _graphics;
+            set {
+                if (_graphics != null) _graphics.PropertyChanged -= OnSubSettingsPropertyChanged;
+                if (SetProperty(ref _graphics, value) && _graphics != null) {
+                    _graphics.PropertyChanged += OnSubSettingsPropertyChanged;
+                }
+            }
+        }
+
+        [SettingHidden]
+        private ProjectExportSettings _export = new();
+        public ProjectExportSettings Export {
+            get => _export;
+            set {
+                if (_export != null) _export.PropertyChanged -= OnSubSettingsPropertyChanged;
+                if (SetProperty(ref _export, value) && _export != null) {
+                    _export.PropertyChanged += OnSubSettingsPropertyChanged;
+                }
+            }
+        }
+
+        [SettingHidden]
+        private LandscapeToolsSettings _landscapeTools = new();
+        public LandscapeToolsSettings LandscapeTools {
+            get => _landscapeTools;
+            set {
+                if (_landscapeTools != null) _landscapeTools.PropertyChanged -= OnSubSettingsPropertyChanged;
+                if (SetProperty(ref _landscapeTools, value) && _landscapeTools != null) {
+                    _landscapeTools.PropertyChanged += OnSubSettingsPropertyChanged;
+                }
+            }
+        }
+
+        private void OnSubSettingsPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e) {
+            RequestSave();
+        }
+
         private CancellationTokenSource? _saveCts;
 
         public ProjectSettings() {
             PropertyChanged += (s, e) => RequestSave();
+
+            if (_graphics != null) _graphics.PropertyChanged += OnSubSettingsPropertyChanged;
+            if (_export != null) _export.PropertyChanged += OnSubSettingsPropertyChanged;
+            if (_landscapeTools != null) _landscapeTools.PropertyChanged += OnSubSettingsPropertyChanged;
         }
 
         [SettingHidden]
@@ -77,27 +121,6 @@ namespace WorldBuilder.Lib.Settings {
         private int _landscapeCameraFieldOfView = 60;
         public int LandscapeCameraFieldOfView { get => _landscapeCameraFieldOfView; set => SetProperty(ref _landscapeCameraFieldOfView, value); }
 
-        [SettingDisplayName("Overwrite DAT Files")]
-        [SettingDescription("Whether to overwrite existing DAT files when exporting.")]
-        private bool _overwriteDatFiles = true;
-        public bool OverwriteDatFiles { get => _overwriteDatFiles; set => SetProperty(ref _overwriteDatFiles, value); }
-
-        [SettingDescription("Last directory used for DAT export")]
-        [SettingPath(PathType.Folder, DialogTitle = "Select Last DAT Export Directory")]
-        private string _lastDatExportDirectory = string.Empty;
-        public string LastDatExportDirectory { get => _lastDatExportDirectory; set => SetProperty(ref _lastDatExportDirectory, value); }
-
-        [SettingDescription("Last portal iteration used for DAT export")]
-        private int _lastDatExportPortalIteration = 0;
-        public int LastDatExportPortalIteration { get => _lastDatExportPortalIteration; set => SetProperty(ref _lastDatExportPortalIteration, value); }
-
-        [SettingDisplayName("Anisotropic Filtering")]
-        [SettingDescription("Improves texture clarity at sharp viewing angles.")]
-        private bool _enableAnisotropicFiltering = true;
-        public bool EnableAnisotropicFiltering { 
-            get => _enableAnisotropicFiltering; 
-            set => SetProperty(ref _enableAnisotropicFiltering, value); 
-        }
 
         [JsonIgnore]
         [SettingHidden]
@@ -150,5 +173,47 @@ namespace WorldBuilder.Lib.Settings {
 
             return new ProjectSettings { FilePath = filePath };
         }
+    }
+
+    [SettingCategory("Graphics", ParentCategory = "Project", Order = 0)]
+    public partial class ProjectGraphicsSettings : ObservableObject {
+        [SettingDisplayName("Anisotropic Filtering")]
+        [SettingDescription("Improves texture clarity at sharp viewing angles.")]
+        private bool _enableAnisotropicFiltering = true;
+        public bool EnableAnisotropicFiltering { 
+            get => _enableAnisotropicFiltering; 
+            set => SetProperty(ref _enableAnisotropicFiltering, value); 
+        }
+    }
+
+    [SettingCategory("Export", ParentCategory = "Project", Order = 1)]
+    public partial class ProjectExportSettings : ObservableObject {
+        [SettingDisplayName("Overwrite DAT Files")]
+        [SettingDescription("Whether to overwrite existing DAT files when exporting.")]
+        private bool _overwriteDatFiles = true;
+        public bool OverwriteDatFiles { get => _overwriteDatFiles; set => SetProperty(ref _overwriteDatFiles, value); }
+
+        [SettingDescription("Last directory used for DAT export")]
+        [SettingPath(PathType.Folder, DialogTitle = "Select Last DAT Export Directory")]
+        private string _lastDatExportDirectory = string.Empty;
+        public string LastDatExportDirectory { get => _lastDatExportDirectory; set => SetProperty(ref _lastDatExportDirectory, value); }
+
+        [SettingDescription("Last portal iteration used for DAT export")]
+        private int _lastDatExportPortalIteration = 0;
+        public int LastDatExportPortalIteration { get => _lastDatExportPortalIteration; set => SetProperty(ref _lastDatExportPortalIteration, value); }
+    }
+
+    [SettingCategory("Landscape Tools", ParentCategory = "Project", Order = 2)]
+    public partial class LandscapeToolsSettings : ObservableObject {
+        [SettingDisplayName("Saved Brush Size")]
+        [SettingDescription("Default brush size for landscape tools.")]
+        [SettingRange(1.0, 50.0, 1.0, 5.0)]
+        private float _brushSize = 5.0f;
+        public float BrushSize { get => _brushSize; set => SetProperty(ref _brushSize, value); }
+
+        [SettingDisplayName("Saved Tool Filtering Option")]
+        [SettingDescription("Default filtering option used by the landscape brush tools.")]
+        private int _toolFilteringOption = 0; 
+        public int ToolFilteringOption { get => _toolFilteringOption; set => SetProperty(ref _toolFilteringOption, value); }
     }
 }

--- a/WorldBuilder/ViewModels/ExportDatsWindowViewModel.cs
+++ b/WorldBuilder/ViewModels/ExportDatsWindowViewModel.cs
@@ -70,9 +70,9 @@ namespace WorldBuilder.ViewModels {
             _dats = dats;
             _datExportService = datExportService;
 
-            ExportDirectory = !string.IsNullOrEmpty(_settings.Project?.LastDatExportDirectory) ? _settings.Project.LastDatExportDirectory : _settings.App.ProjectsDirectory;
-            PortalIteration = (_settings.Project?.LastDatExportPortalIteration ?? 0) > 0 ? _settings.Project!.LastDatExportPortalIteration : _dats.PortalIteration;
-            OverwriteFiles = _settings.Project?.OverwriteDatFiles ?? true;
+            ExportDirectory = !string.IsNullOrEmpty(_settings.Project?.Export.LastDatExportDirectory) ? _settings.Project.Export.LastDatExportDirectory : _settings.App.ProjectsDirectory;
+            PortalIteration = (_settings.Project?.Export.LastDatExportPortalIteration ?? 0) > 0 ? _settings.Project!.Export.LastDatExportPortalIteration : _dats.PortalIteration;
+            OverwriteFiles = _settings.Project?.Export.OverwriteDatFiles ?? true;
 
             Validate();
         }
@@ -111,9 +111,9 @@ namespace WorldBuilder.ViewModels {
                 var success = await _datExportService.ExportDatsAsync(ExportDirectory, PortalIteration, OverwriteFiles, progressHandler);
                 if (success) {
                     if (_settings.Project is not null) {
-                        _settings.Project.LastDatExportDirectory = ExportDirectory;
-                        _settings.Project.LastDatExportPortalIteration = PortalIteration;
-                        _settings.Project.OverwriteDatFiles = OverwriteFiles;
+                        _settings.Project.Export.LastDatExportDirectory = ExportDirectory;
+                        _settings.Project.Export.LastDatExportPortalIteration = PortalIteration;
+                        _settings.Project.Export.OverwriteDatFiles = OverwriteFiles;
                     }
                     _settings.Save();
 


### PR DESCRIPTION
changes i made: 

- organized existing project settings into logical categories (Graphics, Export, Landscape Tools).

- added new requested settings for landscape tools (Brush Size, Filtering Option) with default values.

here are some screenshots of the organization:

<img width="733" height="563" alt="settings1" src="https://github.com/user-attachments/assets/46bb4b82-a0f2-440e-ac78-c6018480ac8d" />
<img width="872" height="594" alt="settings2" src="https://github.com/user-attachments/assets/b99ab47a-d2cc-4d61-a1cc-2cf6f7add36a" />
<img width="760" height="575" alt="settings3" src="https://github.com/user-attachments/assets/f690b17a-df4d-4a19-9f72-534557da7449" />

let me know if anything needs adjusting :)
