### PR TITLE
added camera speed visual feedback and shift modifier

### DIFF
--- a/WorldBuilder/Views/RenderView.axaml
+++ b/WorldBuilder/Views/RenderView.axaml
@@ -8,6 +8,7 @@
     x:DataType="vm:RenderViewModel">
     <Grid x:DataType="vm:RenderViewModel">
         <Panel x:Name="Viewport" Background="Transparent" />
+        
         <Border x:Name="LoadingIndicator" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="10" Padding="8,4" Background="{DynamicResource SemiColorFill0}" CornerRadius="4" IsVisible="False">
             <StackPanel Orientation="Horizontal">
                 <TextBlock Text="⏳" VerticalAlignment="Center" Margin="0,0,8,0" Foreground="{DynamicResource SemiColorText0}" FontSize="14" />
@@ -18,5 +19,14 @@
                 </TextBlock>
             </StackPanel>
         </Border>
+
+        <Border x:Name="SpeedFeedbackPopup" VerticalAlignment="Bottom" HorizontalAlignment="Center" Margin="10,10,10,40" Padding="16,8" Background="{DynamicResource SemiColorFill0}" CornerRadius="6" IsVisible="False">
+            <TextBlock x:Name="SpeedFeedbackText" Text="Camera Speed: 1000" VerticalAlignment="Center" Foreground="{DynamicResource SemiColorText0}" FontSize="14" FontWeight="Bold">
+                <TextBlock.Effect>
+                    <DropShadowEffect BlurRadius="2" OffsetX="1" OffsetY="1" Opacity="0.8" />
+                </TextBlock.Effect>
+            </TextBlock>
+        </Border>
+        
     </Grid>
 </views:Base3DViewport>

--- a/WorldBuilder/Views/RenderView.axaml.cs
+++ b/WorldBuilder/Views/RenderView.axaml.cs
@@ -216,8 +216,30 @@ public partial class RenderView : Base3DViewport {
         }
     }
 
+    private DispatcherTimer? _speedFeedbackTimer;
+
     protected override void OnGlPointerWheelChanged(PointerWheelEventArgs e) {
-        _gameScene?.HandlePointerWheelChanged((float)e.Delta.Y);
+        float multiplier = (e.KeyModifiers & KeyModifiers.Shift) != 0 ? 2.0f : 1.0f;
+        
+        _gameScene?.HandlePointerWheelChanged((float)e.Delta.Y * multiplier);
+
+        if (_gameScene?.CurrentCamera is Camera3D cam3d) {
+            ShowSpeedFeedback(cam3d.MoveSpeed);
+        }
+    }
+
+    private void ShowSpeedFeedback(float speed) {
+        SpeedFeedbackText.Text = $"Camera Speed: {speed:F0}";
+        
+        SpeedFeedbackPopup.IsVisible = true;
+
+        _speedFeedbackTimer?.Stop();
+        _speedFeedbackTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1.5) };
+        _speedFeedbackTimer.Tick += (s, e) => {
+            SpeedFeedbackPopup.IsVisible = false;
+            _speedFeedbackTimer.Stop();
+        };
+        _speedFeedbackTimer.Start();
     }
 
     private bool _isLoading;


### PR DESCRIPTION
- added a visual feedback popup in RenderView.axaml that displays the current camera speed when scrolling the mouse wheel

- the popup automatically fades/hides after 1.5 seconds.

- implemented a Shift key modifier check in RenderView.axaml.cs that doubles the mouse wheel delta, allowing for faster camera speed adjustments

<img width="416" height="147" alt="camera_speed" src="https://github.com/user-attachments/assets/c539fce7-89b0-44db-bd99-8b4d23cce09d" />
