### PR TITLE
keep file menu visible for ready-only projects/hide export

### DIFF
--- a/WorldBuilder/Views/MainView.axaml
+++ b/WorldBuilder/Views/MainView.axaml
@@ -27,9 +27,9 @@
         <!--  Menu Bar at the top  -->
         <Grid DockPanel.Dock="Top" ColumnDefinitions="*, Auto">
             <Menu Grid.Column="0">
-                <MenuItem Header="File" IsVisible="{Binding !IsReadOnly}">
+                <MenuItem Header="File">
                     <MenuItem Command="{Binding OpenCommand}" Header="Open" />
-                    <MenuItem Command="{Binding OpenExportDatsWindowCommand}" Header="Export Dats" />
+                    <MenuItem Command="{Binding OpenExportDatsWindowCommand}" Header="Export Dats" IsVisible="{Binding !IsReadOnly}" />
                     <MenuItem Command="{Binding CloseProjectCommand}" Header="Close" />
                     <MenuItem Command="{Binding ExitApplicationCommand}" Header="Exit" InputGesture="{Binding ExitHotkeyText, Converter={StaticResource StringToKeyGestureConverter}}" />
                 </MenuItem>


### PR DESCRIPTION
- removed the IsVisible="{Binding !IsReadOnly}" condition from the main File MenuItem so the menu remains accessible at all times

- moved the IsVisible="{Binding !IsReadOnly}" condition directly to the Export Dats MenuItem so it correctly hides only the export functionality when a read-only project is opened