### PR TITLE
fixed overlay colors for visibility

### DIFF
--- a/WorldBuilder/Modules/Landscape/LandscapeView.axaml
+++ b/WorldBuilder/Modules/Landscape/LandscapeView.axaml
@@ -97,10 +97,10 @@
 
         <!-- Time of Day Overlay -->
         <Border HorizontalAlignment="Right" VerticalAlignment="Top" Margin="8,48,8,8"
-                Background="{DynamicResource SemiColorFill0}" BorderBrush="{DynamicResource SemiColorBorder}" BorderThickness="1"
+                Background="#AA000000" BorderBrush="Transparent" BorderThickness="1"
                 CornerRadius="4" Padding="8,4" Width="200">
           <Grid ColumnDefinitions="Auto, *">
-            <icons:MaterialIcon Kind="WeatherSunny" Margin="0,0,8,0" Foreground="{DynamicResource SemiColorText0}" />
+            <icons:MaterialIcon Kind="WeatherSunny" Margin="0,0,8,0" Foreground="White" />
             <Slider Grid.Column="1" Minimum="0" Maximum="1" Value="{Binding EditorState.TimeOfDay}" 
                     ToolTip.Tip="Time of Day" />
           </Grid>
@@ -108,11 +108,11 @@
         
         <!-- Location Overlay -->
         <Border HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="10" 
-                Background="{DynamicResource SemiColorFill0}" BorderBrush="{DynamicResource SemiColorBorder}" BorderThickness="1"
+                Background="#AA000000" BorderBrush="Transparent" BorderThickness="1"
                 CornerRadius="4" Padding="6,4">
           <StackPanel Orientation="Horizontal" Spacing="8">
             <TextBlock x:Name="LocationText"
-                       Foreground="{DynamicResource SemiColorText0}"
+                       Foreground="White"
                        FontFamily="Consolas, Monospace"
                        FontSize="12"
                        VerticalAlignment="Center"
@@ -120,7 +120,7 @@
             <Button x:Name="CopyLocationButton" 
                     Background="Transparent" BorderThickness="0" Padding="2" Width="24" Height="24"
                     ToolTip.Tip="Copy Location">
-              <icons:MaterialIcon Kind="ContentCopy" Width="14" Height="14" />
+              <icons:MaterialIcon Kind="ContentCopy" Width="14" Height="14" Foreground="White" />
             </Button>
           </StackPanel>
         </Border>

--- a/WorldBuilder/Views/RenderView.axaml
+++ b/WorldBuilder/Views/RenderView.axaml
@@ -9,10 +9,10 @@
     <Grid x:DataType="vm:RenderViewModel">
         <Panel x:Name="Viewport" Background="Transparent" />
         
-        <Border x:Name="LoadingIndicator" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="10" Padding="8,4" Background="{DynamicResource SemiColorFill0}" CornerRadius="4" IsVisible="False">
+        <Border x:Name="LoadingIndicator" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="10" Padding="8,4" Background="#AA000000" CornerRadius="4" IsVisible="False">
             <StackPanel Orientation="Horizontal">
-                <TextBlock Text="⏳" VerticalAlignment="Center" Margin="0,0,8,0" Foreground="{DynamicResource SemiColorText0}" FontSize="14" />
-                <TextBlock x:Name="LoadingText" Text="0" VerticalAlignment="Center" Foreground="{DynamicResource SemiColorText0}" FontSize="12" FontWeight="SemiBold">
+                <TextBlock Text="⏳" VerticalAlignment="Center" Margin="0,0,8,0" Foreground="White" FontSize="14" />
+                <TextBlock x:Name="LoadingText" Text="0" VerticalAlignment="Center" Foreground="White" FontSize="12" FontWeight="SemiBold">
                     <TextBlock.Effect>
                         <DropShadowEffect BlurRadius="2" OffsetX="1" OffsetY="1" Opacity="0.8" />
                     </TextBlock.Effect>
@@ -20,8 +20,8 @@
             </StackPanel>
         </Border>
 
-        <Border x:Name="SpeedFeedbackPopup" VerticalAlignment="Bottom" HorizontalAlignment="Center" Margin="10,10,10,40" Padding="16,8" Background="{DynamicResource SemiColorFill0}" CornerRadius="6" IsVisible="False">
-            <TextBlock x:Name="SpeedFeedbackText" Text="Camera Speed: 1000" VerticalAlignment="Center" Foreground="{DynamicResource SemiColorText0}" FontSize="14" FontWeight="Bold">
+        <Border x:Name="SpeedFeedbackPopup" VerticalAlignment="Bottom" HorizontalAlignment="Center" Margin="10,10,10,40" Padding="16,8" Background="#AA000000" CornerRadius="6" IsVisible="False">
+            <TextBlock x:Name="SpeedFeedbackText" Text="Camera Speed: 1000" VerticalAlignment="Center" Foreground="White" FontSize="14" FontWeight="Bold">
                 <TextBlock.Effect>
                     <DropShadowEffect BlurRadius="2" OffsetX="1" OffsetY="1" Opacity="0.8" />
                 </TextBlock.Effect>


### PR DESCRIPTION
- changed the Background and Foreground properties of the 3D viewport overlays from dynamic theme colors to hardcoded values (dark semi-transparent background with white text/icons). This ensures they remain fully legible against the 3D scene, regardless of whether the app is in light or dark mode

<img width="1440" height="191" alt="dark-theme" src="https://github.com/user-attachments/assets/a21b5bd8-e283-46cc-8215-46f602333359" />
<img width="493" height="166" alt="dark-theme2" src="https://github.com/user-attachments/assets/4993edaa-c30a-4837-897e-cf9db65536e2" />
<img width="1677" height="974" alt="dark-theme3" src="https://github.com/user-attachments/assets/e61d1f6e-44be-419c-99d4-beec87539cff" />
<img width="1080" height="220" alt="light-theme" src="https://github.com/user-attachments/assets/50b1bc0f-4644-4bf4-8d8e-ebf7d2c017d4" />
<img width="535" height="180" alt="light-theme2" src="https://github.com/user-attachments/assets/5b1e0538-d6c5-442e-ac74-4b06a22673e3" />
<img width="1619" height="946" alt="light-theme3" src="https://github.com/user-attachments/assets/822f839e-6ad4-486b-b8c5-c9ac9eca60f5" />
