### PR TITLE
added GPU debug window

### DIFF
--- a/WorldBuilder/ViewModels/MainViewModel.cs
+++ b/WorldBuilder/ViewModels/MainViewModel.cs
@@ -43,6 +43,7 @@ public partial class MainViewModel : ViewModelBase, IDisposable, IRecipient<Open
     private readonly PerformanceService _performanceService;
     private readonly CancellationTokenSource _cts = new();
     private Window? _settingsWindow;
+    private Window? _gpuDebugWindow;
 
     /// <summary>
     /// Gets a value indicating whether the application is in dark mode.
@@ -314,6 +315,28 @@ public partial class MainViewModel : ViewModelBase, IDisposable, IRecipient<Open
 
         viewModel.Closed += (s, e) => _settingsWindow = null;
     }
+
+    [RelayCommand]
+     private void OpenGpuDebugWindow() {
+         if (_gpuDebugWindow != null) {
+             _gpuDebugWindow.Activate();
+             return;
+         }
+
+         _gpuDebugWindow = new Views.GpuDebugWindow {
+             DataContext = this 
+         };
+
+         var desktop = Avalonia.Application.Current?.ApplicationLifetime as Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime;
+         if (desktop?.MainWindow != null) {
+             _gpuDebugWindow.Show(desktop.MainWindow);
+         }
+         else {
+             _gpuDebugWindow.Show();
+         }
+
+         _gpuDebugWindow.Closed += (s, e) => _gpuDebugWindow = null;
+     }
 
     [RelayCommand]
     private void OpenDebugWindow() {

--- a/WorldBuilder/Views/GpuDebugWindow.axaml
+++ b/WorldBuilder/Views/GpuDebugWindow.axaml
@@ -1,0 +1,24 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:WorldBuilder.ViewModels"
+        x:DataType="vm:MainViewModel"
+        x:Class="WorldBuilder.Views.GpuDebugWindow"
+        Title="GPU Debug"
+        Width="400" Height="500"
+        WindowStartupLocation="CenterOwner">
+
+    <ScrollViewer>
+        <Border Padding="15">
+            <StackPanel Spacing="15">
+                <TextBlock Text="GPU Buffer Sizes" FontWeight="Bold" FontSize="16" />
+                <TextBlock Text="{Binding VramDetailsTooltip}" TextWrapping="Wrap" />
+                
+                <Separator />
+                
+                <TextBlock Text="Render Times" FontWeight="Bold" FontSize="16" />
+                <TextBlock Text="{Binding RenderTimeDetailsTooltip}" />
+            </StackPanel>
+        </Border>
+    </ScrollViewer>
+    
+</Window>

--- a/WorldBuilder/Views/GpuDebugWindow.axaml.cs
+++ b/WorldBuilder/Views/GpuDebugWindow.axaml.cs
@@ -1,0 +1,9 @@
+using Avalonia.Controls;
+
+namespace WorldBuilder.Views;
+
+public partial class GpuDebugWindow : Window {
+    public GpuDebugWindow() {
+        InitializeComponent();
+    }
+}

--- a/WorldBuilder/Views/MainView.axaml
+++ b/WorldBuilder/Views/MainView.axaml
@@ -30,11 +30,12 @@
                     <MenuItem Command="{Binding CloseProjectCommand}" Header="Close" />
                     <MenuItem Command="{Binding ExitApplicationCommand}" Header="Exit" InputGesture="{Binding ExitHotkeyText, Converter={StaticResource StringToKeyGestureConverter}}" />
                 </MenuItem>
-                <!--
+                
                 <MenuItem Header="Debug">
-                    <MenuItem Command="{Binding OpenDebugWindowCommand}" Header="Open Debug Window" />
+                    <MenuItem Command="{Binding OpenDebugWindowCommand}" Header="Avalonia Debug" />
+                    <MenuItem Command="{Binding OpenGpuDebugWindowCommand}" Header="GPU Debug" />
                 </MenuItem>
-                -->
+                
                 <MenuItem Command="{Binding OpenSettingsWindowCommand}" Header="Settings" />
             </Menu>
 


### PR DESCRIPTION
- created a new GpuDebugWindow to display GPU buffer sizes and Render Times

- reused the existing properties (VramDetailsTooltip and RenderTimeDetailsTooltip) from MainViewModel as the DataContext

- uncommented the Debug menu in MainView.axaml and added the new GPU Debug MenuItem

- wrapped the debug window content in a ScrollViewer to gracefully handle large lists of buffer data