### PR TITLE
added application log window

### DIFF
--- a/WorldBuilder.Windows/WorldBuilder.Windows.csproj
+++ b/WorldBuilder.Windows/WorldBuilder.Windows.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<OutputType>Exe</OutputType>
+		<OutputType>WinExe</OutputType>
 		<BuiltInComInteropSupport>true</BuiltInComInteropSupport>
 		<ApplicationManifest>app.manifest</ApplicationManifest>
 		<PublishTrimmed>true</PublishTrimmed>

--- a/WorldBuilder/Lib/Extensions/ServiceCollectionExtensions.cs
+++ b/WorldBuilder/Lib/Extensions/ServiceCollectionExtensions.cs
@@ -28,6 +28,7 @@ namespace WorldBuilder.Lib.Extensions {
             collection.AddLogging((c) => {
                 c.AddProvider(new ColorConsoleLoggerProvider());
                 c.SetMinimumLevel(LogLevel.Debug);
+                c.Services.AddSingleton<ILoggerProvider>(sp => new AppLogProvider(sp.GetRequiredService<AppLogService>()));
             });
 
             collection.AddSingleton<WorldBuilderSettings>();
@@ -39,6 +40,8 @@ namespace WorldBuilder.Lib.Extensions {
             collection.AddSingleton<SharedOpenGLContextManager>();
             collection.AddSingleton<PerformanceService>();
             collection.AddSingleton<BookmarksManager>();
+            collection.AddSingleton<AppLogService>();
+            
 
             // Register dialog service
             collection.AddSingleton<IDialogService>(provider => new DialogService(
@@ -97,6 +100,7 @@ namespace WorldBuilder.Lib.Extensions {
             collection.AddSingleton(rootProvider.GetRequiredService<IDialogService>());
             collection.AddSingleton(rootProvider.GetRequiredService<PerformanceService>());
             collection.AddSingleton(rootProvider.GetRequiredService<BookmarksManager>());
+            collection.AddSingleton(rootProvider.GetRequiredService<AppLogService>());
 
             collection.AddSingleton((Project)project);
             collection.AddSingleton<IProject>(project);

--- a/WorldBuilder/Services/AppLogProvider.cs
+++ b/WorldBuilder/Services/AppLogProvider.cs
@@ -1,0 +1,51 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace WorldBuilder.Services;
+
+// provider that creates our custom logger
+public class AppLogProvider : ILoggerProvider {
+    private readonly AppLogService _appLogService;
+
+    public AppLogProvider(AppLogService appLogService) {
+        _appLogService = appLogService;
+    }
+
+    public ILogger CreateLogger(string categoryName) {
+        return new AppLogger(_appLogService, categoryName);
+    }
+
+    public void Dispose() { }
+}
+
+// actual logger that catches messages
+public class AppLogger : ILogger {
+    private readonly AppLogService _appLogService;
+    private readonly string _categoryName;
+
+    public AppLogger(AppLogService appLogService, string categoryName) {
+        _appLogService = appLogService;
+        _categoryName = categoryName;
+    }
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true; // Catch everything
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) {
+        if (!IsEnabled(logLevel)) return;
+
+        var message = formatter(state, exception);
+        var fullMessage = $"[{_categoryName}] {message}";
+
+        if (exception != null) {
+            fullMessage += $"\nException: {exception.Message}\n{exception.StackTrace}";
+        }
+
+        if (logLevel == LogLevel.Error || logLevel == LogLevel.Critical || exception != null) {
+            _appLogService.LogError(fullMessage);
+        } else {
+            _appLogService.LogInfo(fullMessage);
+        }
+    }
+}

--- a/WorldBuilder/Services/AppLogService.cs
+++ b/WorldBuilder/Services/AppLogService.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.ObjectModel;
+using Avalonia.Threading;
+
+namespace WorldBuilder.Services;
+
+public class LogEntry {
+    public DateTime Timestamp { get; set; }
+    public string Message { get; set; } = string.Empty;
+    public string Type { get; set; } = "Info"; // "Info", "Error", "Warning"
+}
+
+public class AppLogService {
+    public ObservableCollection<LogEntry> Logs { get; } = new();
+    
+    // trigger the UI to automatically open the log window on errors
+    public event EventHandler<LogEntry>? OnErrorLogged;
+
+    public void LogInfo(string message) {
+        AddLog(new LogEntry { Timestamp = DateTime.Now, Message = message, Type = "Info" });
+    }
+
+    public void LogError(string message) {
+        var entry = new LogEntry { Timestamp = DateTime.Now, Message = message, Type = "Error" };
+        AddLog(entry);
+        
+        Dispatcher.UIThread.Post(() => OnErrorLogged?.Invoke(this, entry));
+    }
+
+    private void AddLog(LogEntry entry) {
+        Dispatcher.UIThread.Post(() => {
+            Logs.Add(entry);
+            // to prevent memory leaks, keep the last 1000 log entries
+            if (Logs.Count > 1000) {
+                Logs.RemoveAt(0);
+            }
+        });
+    }
+}

--- a/WorldBuilder/ViewModels/MainViewModel.cs
+++ b/WorldBuilder/ViewModels/MainViewModel.cs
@@ -44,6 +44,8 @@ public partial class MainViewModel : ViewModelBase, IDisposable, IRecipient<Open
     private readonly CancellationTokenSource _cts = new();
     private Window? _settingsWindow;
     private Window? _gpuDebugWindow;
+    private Window? _appLogWindow;
+    private AppLogService? _appLogService;
 
     /// <summary>
     /// Gets a value indicating whether the application is in dark mode.
@@ -143,6 +145,11 @@ public partial class MainViewModel : ViewModelBase, IDisposable, IRecipient<Open
         _themeService.PropertyChanged += OnThemeServicePropertyChanged;
 
         WeakReferenceMessenger.Default.RegisterAll(this);
+
+        _appLogService = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<AppLogService>(_serviceProvider);
+        _appLogService.OnErrorLogged += (s, e) => {
+            Avalonia.Threading.Dispatcher.UIThread.Post(() => OpenAppLogWindow());
+        };
 
         _ = UpdateStatsLoop();
     }
@@ -337,6 +344,28 @@ public partial class MainViewModel : ViewModelBase, IDisposable, IRecipient<Open
 
          _gpuDebugWindow.Closed += (s, e) => _gpuDebugWindow = null;
      }
+
+    [RelayCommand]
+    private void OpenAppLogWindow() {
+        if (_appLogWindow != null) {
+            _appLogWindow.Activate();
+            return;
+        }
+
+        if (_appLogService == null) return;
+
+        _appLogWindow = new Views.AppLogWindow(_appLogService);
+
+        var desktop = Avalonia.Application.Current?.ApplicationLifetime as Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime;
+        if (desktop?.MainWindow != null) {
+            _appLogWindow.Show(desktop.MainWindow);
+        }
+        else {
+            _appLogWindow.Show();
+        }
+
+        _appLogWindow.Closed += (s, e) => _appLogWindow = null;
+    }
 
     [RelayCommand]
     private void OpenDebugWindow() {

--- a/WorldBuilder/Views/AppLogWindow.axaml
+++ b/WorldBuilder/Views/AppLogWindow.axaml
@@ -1,0 +1,26 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:services="using:WorldBuilder.Services"
+        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+        x:Class="WorldBuilder.Views.AppLogWindow"
+        x:DataType="services:AppLogService"
+        Title="Application Logs"
+        Width="800" Height="400"
+        WindowStartupLocation="CenterOwner">
+
+    <Grid>
+        <ListBox ItemsSource="{Binding Logs}" Background="Transparent">
+            <ListBox.ItemTemplate>
+                <DataTemplate x:DataType="services:LogEntry">
+                    <StackPanel Orientation="Horizontal" Spacing="10" Margin="0,2">
+                        <TextBlock Text="{Binding Timestamp, StringFormat='HH:mm:ss'}" Opacity="0.5" FontFamily="Consolas" />
+                        <TextBlock Text="{Binding Type}" FontWeight="Bold" Width="60" />
+                        <TextBlock Text="{Binding Message}" TextWrapping="Wrap" FontFamily="Consolas" />
+                    </StackPanel>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+    </Grid>
+</Window>

--- a/WorldBuilder/Views/AppLogWindow.axaml.cs
+++ b/WorldBuilder/Views/AppLogWindow.axaml.cs
@@ -1,0 +1,14 @@
+using Avalonia.Controls;
+using WorldBuilder.Services;
+
+namespace WorldBuilder.Views;
+
+public partial class AppLogWindow : Window {
+    public AppLogWindow() {
+        InitializeComponent();
+    }
+
+    public AppLogWindow(AppLogService logService) : this() {
+        DataContext = logService;
+    }
+}

--- a/WorldBuilder/Views/MainView.axaml
+++ b/WorldBuilder/Views/MainView.axaml
@@ -34,6 +34,7 @@
                 <MenuItem Header="Debug">
                     <MenuItem Command="{Binding OpenDebugWindowCommand}" Header="Avalonia Debug" />
                     <MenuItem Command="{Binding OpenGpuDebugWindowCommand}" Header="GPU Debug" />
+                    <MenuItem Command="{Binding OpenAppLogWindowCommand}" Header="App Logs" />
                 </MenuItem>
                 
                 <MenuItem Command="{Binding OpenSettingsWindowCommand}" Header="Settings" />


### PR DESCRIPTION
 - changed `OutputType` to `WinExe` in `WorldBuilder.Windows.csproj` to prevent the console window from popping up in the background
- implemented a custom `ILoggerProvider` (`AppLogProvider`) to intercept all application logs and route them to a new central `AppLogService`. The service maintains a rolling buffer of the last 1000 logs to prevent memory leaks
- created `AppLogWindow.axaml` to display the logs, including timestamps, log levels, and messages using data binding
- wired the window to the `MainViewModel`. Added an "App Logs" item under the "Debug" menu for manual access. The window is also configured to automatically pop up when an `Error` or `Critical` level log is captured
- properly registered the logging service across the core and project-level service collections to ensure it captures logs from the moment the app starts to when a project is loaded

tested locally, logs are caught and the UI updates in real-time.


<img width="1345" height="670" alt="app log2" src="https://github.com/user-attachments/assets/e1234248-d68d-4c90-b8d0-79d19a2d8ee8" />
<img width="260" height="173" alt="app-log" src="https://github.com/user-attachments/assets/f8caad9a-3f25-4bbc-a006-8b48ca27f25b" />
