### PR TITLE
added file logging using Serilog

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,6 +36,8 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
     <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageVersion Include="SixLabors.Fonts" Version="2.1.3" />
     <PackageVersion Include="SixLabors.ImageSharp.Drawing" Version="2.1.7" />
     <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="2.1.11" />

--- a/WorldBuilder/Lib/ApplicationBootstrapper.cs
+++ b/WorldBuilder/Lib/ApplicationBootstrapper.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Serilog; 
 using System;
 using WorldBuilder.Lib.Extensions;
 using WorldBuilder.Services;
@@ -16,12 +17,26 @@ namespace WorldBuilder.Lib {
         /// <returns>A configured IServiceProvider instance</returns>
         public static IServiceProvider BuildServiceProvider(CommandLineOptions options) {
             var services = new ServiceCollection();
-
-            // Add core application services
+        
+            var logPath = Path.Combine(AppContext.BaseDirectory, "logs", "worldbuilder.log");
+            
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .WriteTo.File(logPath, 
+                    rollingInterval: RollingInterval.Day,
+                    flushToDiskInterval: TimeSpan.FromSeconds(1),
+                    shared: true) 
+                .CreateLogger();
+        
+            services.AddLogging(builder => {
+                builder.ClearProviders();
+                builder.AddSerilog(dispose: true);
+            });
+        
             services.AddSingleton(options);
             services.AddWorldBuilderCoreServices();
             services.AddWorldBuilderViewModels();
-
+        
             return services.BuildServiceProvider();
         }
 

--- a/WorldBuilder/WorldBuilder.csproj
+++ b/WorldBuilder/WorldBuilder.csproj
@@ -27,6 +27,8 @@
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
 		<PackageReference Include="HanumanInstitute.MvvmDialogs.Avalonia" />
+		<PackageReference Include="Serilog.Extensions.Logging" />
+		<PackageReference Include="Serilog.Sinks.File" />
 		<PackageReference Include="Velopack" />
 	</ItemGroup>
 


### PR DESCRIPTION
- added Serilog.Extensions.Logging and Serilog.Sinks.File packages.

- configured the logger to write to logs/worldbuilder.log with a 1-second flush interval and daily rolling files.

- used flushToDiskInterval to guarantee that logs are written nearly in real-time, helping catch stack traces during application crashes.

verified that a logs folder is created in the output directory of the WorldBuilder.Windows project and confirmed that log files (e.g., worldbuilder20260307.log) are generated and populated with application startup events.

<img width="737" height="180" alt="logs" src="https://github.com/user-attachments/assets/ce32009f-217d-4431-80da-88575a86a243" />
<img width="697" height="291" alt="logs2" src="https://github.com/user-attachments/assets/4719c26b-2909-432f-aea7-a83a0d4afeeb" />
<img width="805" height="253" alt="logs3" src="https://github.com/user-attachments/assets/86b7578a-af6c-41fd-9072-6ae3ce574276" />
