### PR TITLE
fix SingleObjectScene FreeCam

### DIFF
--- a/Chorizite.OpenGLSDLBackend/SingleObjectScene.cs
+++ b/Chorizite.OpenGLSDLBackend/SingleObjectScene.cs
@@ -254,6 +254,7 @@ namespace Chorizite.OpenGLSDLBackend {
                 }
             }
             else {
+                // Freecam
                 if (deltaTime > 0) NeedsRender = true;
             }
         }


### PR DESCRIPTION
The states in here are getting a bit unruly, and are currently just represented by a bunch of separate bools:

```
DatBrowser:
	- Grid Mode
		- Non-hovered (static)
		- Hovered (autospin)
			- Manual spin
	- Single Object Browser
		- Autospin (default)
			- Manual spin
		- Freecam
Tooltip (static)
```

static, autospin, manual spin, freecam
