### PR TITLE
cleanup hotkey tooltips

### DIFF
--- a/WorldBuilder/Converters/HotkeyTooltipConverter.cs
+++ b/WorldBuilder/Converters/HotkeyTooltipConverter.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace WorldBuilder.Converters {
+    /// <summary>
+    /// Converter for hotkey tooltips that returns empty string when hotkey is empty or "None",
+    /// otherwise returns formatted string with hotkey in parentheses.
+    /// </summary>
+    public class HotkeyTooltipConverter : IValueConverter {
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) {
+            var hotkey = value as string;
+            
+            // Return just the action name without parentheses when no hotkey is bound
+            if (string.IsNullOrEmpty(hotkey) || hotkey == "None") {
+                return parameter?.ToString() ?? string.Empty;
+            }
+            
+            // Return formatted string with hotkey in parentheses
+            var actionName = parameter?.ToString() ?? string.Empty;
+            return $"{actionName} ({hotkey})";
+        }
+
+        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/WorldBuilder/Modules/Landscape/Views/Components/BookmarksPanel.axaml
+++ b/WorldBuilder/Modules/Landscape/Views/Components/BookmarksPanel.axaml
@@ -13,6 +13,7 @@
     x:CompileBindings="False"
     x:DataType="landscape:BookmarksPanelViewModel">
     <UserControl.Resources>
+        <conv:HotkeyTooltipConverter x:Key="HotkeyTooltipConverter" />
         <conv:SearchSourceConverter x:Key="SearchSourceConverter" />
         <conv:TreeListSearchSourceConverter x:Key="TreeListSearchSourceConverter" />
         
@@ -39,7 +40,7 @@
     <Grid RowDefinitions="Auto, *">
         <Grid Grid.Row="0" Margin="4" ColumnDefinitions="Auto, *">
             <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="4">
-                <Button Command="{Binding AddBookmarkCommand}" ToolTip.Tip="{Binding AddBookmarkHotkey, StringFormat='Add New Bookmark ({0})'}">
+                <Button Command="{Binding AddBookmarkCommand}" ToolTip.Tip="{Binding AddBookmarkHotkey, Converter={StaticResource HotkeyTooltipConverter}, ConverterParameter='Add New Bookmark'}">
                     <icons:MaterialIcon Kind="Plus" Width="16" Height="16" />
                 </Button>
                 <Button Command="{Binding AddFolderCommand}" ToolTip.Tip="Add New Folder">

--- a/WorldBuilder/Modules/Landscape/Views/Components/ToolSettingsPanel.axaml
+++ b/WorldBuilder/Modules/Landscape/Views/Components/ToolSettingsPanel.axaml
@@ -11,6 +11,7 @@
              x:Name="SettingsRoot"
              x:DataType="vm:LandscapeViewModel">
     <UserControl.Resources>
+      <converters:HotkeyTooltipConverter x:Key="HotkeyTooltipConverter" />
       <converters:TextureToViewModelConverter x:Key="TextureConverter" />
       <libconverters:Vector4ToColorConverter x:Key="Vector4ToColorConverter" />
       
@@ -192,17 +193,17 @@
                                    IsChecked="{Binding Mode, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static gizmo:GizmoMode.Translate}}" 
                                    FontSize="12"
                                    VerticalAlignment="Center"
-                                   ToolTip.Tip="{Binding TranslateHotkey, StringFormat='Translate ({0})'}" />
+                                   ToolTip.Tip="{Binding TranslateHotkey, Converter={StaticResource HotkeyTooltipConverter}, ConverterParameter='Translate'}" />
                       <RadioButton Content="R" 
                                    IsChecked="{Binding Mode, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static gizmo:GizmoMode.Rotate}}" 
                                    FontSize="12"
                                    VerticalAlignment="Center"
-                                   ToolTip.Tip="{Binding RotateHotkey, StringFormat='Rotate ({0})'}" />
+                                   ToolTip.Tip="{Binding RotateHotkey, Converter={StaticResource HotkeyTooltipConverter}, ConverterParameter='Rotate'}" />
                       <RadioButton Content="F" 
                                    IsChecked="{Binding Mode, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static gizmo:GizmoMode.Both}}" 
                                    FontSize="12"
                                    VerticalAlignment="Center"
-                                   ToolTip.Tip="{Binding BothHotkey, StringFormat='Both ({0})'}" />
+                                   ToolTip.Tip="{Binding BothHotkey, Converter={StaticResource HotkeyTooltipConverter}, ConverterParameter='Both'}" />
                     </StackPanel>
                   </HeaderedContentControl>
                   <HeaderedContentControl Header="Options" Template="{StaticResource RibbonGroupTemplate}">


### PR DESCRIPTION
When an action doesn't have a hotkey bound to it, this just shows the standard "Action" for the tooltip, instead of "Action (None)"