### PR TITLE
bookmarks folder dropzone tweaks

### DIFF
--- a/WorldBuilder/Modules/Landscape/ViewModels/BookmarksPanelViewModel.cs
+++ b/WorldBuilder/Modules/Landscape/ViewModels/BookmarksPanelViewModel.cs
@@ -443,6 +443,11 @@ namespace WorldBuilder.Modules.Landscape.ViewModels {
             return null;
         }
 
+        [RelayCommand]
+        public void ClearSearch() {
+            SearchText = string.Empty;
+        }
+
         private void OnKeyBindingsChanged(object? sender, EventArgs e) {
             UpdateHotkeyDisplay();
         }

--- a/WorldBuilder/Modules/Landscape/Views/Components/BookmarksPanel.axaml
+++ b/WorldBuilder/Modules/Landscape/Views/Components/BookmarksPanel.axaml
@@ -61,10 +61,30 @@
                     <icons:MaterialIcon Kind="ArrowRight" Width="16" Height="16" />
                 </Button>
             </StackPanel>
-            <TextBox Grid.Column="1" 
-                     Text="{Binding SearchText}" 
-                     Watermark="Search bookmarks..." 
-                     Margin="4,0,0,0" />
+            <Grid Grid.Column="1" Margin="4,0,0,0">
+                <TextBox Text="{Binding SearchText}" 
+                         Watermark="Search bookmarks..." />
+                <Button HorizontalAlignment="Right" 
+                        VerticalAlignment="Center"
+                        Margin="0,0,8,0"
+                        Padding="4"
+                        Background="Transparent"
+                        BorderThickness="0"
+                        Command="{Binding ClearSearchCommand}"
+                        IsVisible="{Binding SearchText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                    <icons:MaterialIcon Kind="Close" Width="9" Height="9" />
+                    <Button.Styles>
+                        <Style Selector="Button">
+                            <Setter Property="Foreground" Value="{DynamicResource SemiColorText2}" />
+                        </Style>
+                        <Style Selector="Button:pointerover /template/ ContentPresenter">
+                            <Setter Property="Background" Value="Transparent" />
+                            <Setter Property="Foreground" Value="{DynamicResource SemiColorText0}" />
+                            <Setter Property="Opacity" Value="0.95" />
+                        </Style>
+                    </Button.Styles>
+                </Button>
+            </Grid>
         </Grid>
 
         <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">

--- a/WorldBuilder/Modules/Landscape/Views/Components/BookmarksPanel.axaml.cs
+++ b/WorldBuilder/Modules/Landscape/Views/Components/BookmarksPanel.axaml.cs
@@ -153,7 +153,7 @@ public partial class BookmarksPanel : UserControl {
                 if (position.Y < dropZoneSize) {
                     dropPosition = DropPosition.Above;
                 }
-                else if (position.Y > headerHeight + dropZoneSize) {
+                else if (position.Y > headerHeight - dropZoneSize && !targetBookmark.IsExpanded) {
                     dropPosition = DropPosition.Below;
                 }
                 else {


### PR DESCRIPTION
This fixes an issue where items can't be dragged to the end of a list if the last element in the list is currently a folder

When the bookmarks search bar is active, this also adds a small 'x' icon to the right side to easily clear the text